### PR TITLE
Fix duplicate sends when Enter is pressed rapidly in MessageInput

### DIFF
--- a/src/components/molecules/message-input.tsx
+++ b/src/components/molecules/message-input.tsx
@@ -140,6 +140,12 @@ export const MessageInput = ({
 }: MessageInputProps) => {
   const [message, setMessage] = useState('');
   const messageRef = useRef('');
+  // isSendingRef is the synchronous guard consulted on every keypress;
+  // isSending mirrors it as state so the input can dim and lock during
+  // the round trip. On failure the `.finally()` releases both, which
+  // unlocks the field with the user's text preserved for retry.
+  const isSendingRef = useRef(false);
+  const [isSending, setIsSending] = useState(false);
   const [showEmojiPicker, setShowEmojiPicker] = useState(false);
   const [emojiPickerPosition, setEmojiPickerPosition] = useState({ top: 0, left: 0 });
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -150,11 +156,24 @@ export const MessageInput = ({
    * Handles sending the message, clearing the input, and stopping typing indicators
    */
   const handleSend = useCallback(() => {
+    // Block re-entry while a send is in flight so rapid Enter presses
+    // don't fire a second request for the same text.
+    if (isSendingRef.current) return;
     const trimmedMessage = messageRef.current.trim();
-    if (trimmedMessage) {
-      sendMessage({ text: trimmedMessage })
-        .then((sentMessage) => {
-          onSent?.(sentMessage);
+    if (!trimmedMessage) return;
+
+    isSendingRef.current = true;
+    setIsSending(true);
+    // Close any open emoji picker so the user cannot mutate the locked
+    // input while the request is in flight.
+    setShowEmojiPicker(false);
+
+    sendMessage({ text: trimmedMessage })
+      .then((sentMessage) => {
+        onSent?.(sentMessage);
+        // Only clear the input if the user hasn't started composing a
+        // new message while we were waiting.
+        if (messageRef.current.trim() === trimmedMessage) {
           setMessage('');
           messageRef.current = '';
           if (enableTyping) {
@@ -162,15 +181,19 @@ export const MessageInput = ({
               console.warn('Stop typing failed:', error);
             });
           }
-        })
-        .catch((error: unknown) => {
-          if (onSendError) {
-            onSendError(error as ErrorInfo, trimmedMessage);
-          } else {
-            console.error('Failed to send message:', error);
-          }
-        });
-    }
+        }
+      })
+      .catch((error: unknown) => {
+        if (onSendError) {
+          onSendError(error as ErrorInfo, trimmedMessage);
+        } else {
+          console.error('Failed to send message:', error);
+        }
+      })
+      .finally(() => {
+        isSendingRef.current = false;
+        setIsSending(false);
+      });
   }, [sendMessage, stop, onSent, onSendError, enableTyping]);
 
   /**
@@ -292,6 +315,8 @@ export const MessageInput = ({
             placeholder={placeholder}
             className="flex-1"
             aria-label="Message text"
+            disabled={isSending}
+            aria-busy={isSending}
           />
 
           {/* Emoji Button */}
@@ -304,6 +329,7 @@ export const MessageInput = ({
             aria-label="Open emoji picker"
             aria-haspopup="dialog"
             aria-expanded={showEmojiPicker}
+            disabled={isSending}
           >
             <Icon name="emoji" size="md" aria-hidden={true} />
           </Button>

--- a/src/test/components/molecules/message-input.test.tsx
+++ b/src/test/components/molecules/message-input.test.tsx
@@ -41,6 +41,7 @@ vi.mock('../../../components/atoms/button', () => ({
     'aria-label': ariaLabel,
     'aria-haspopup': ariaHasPopup,
     'aria-expanded': ariaExpanded,
+    disabled,
   }: ButtonProps) => (
     <button
       onClick={onClick}
@@ -50,6 +51,7 @@ vi.mock('../../../components/atoms/button', () => ({
       aria-label={ariaLabel}
       aria-haspopup={ariaHasPopup}
       aria-expanded={ariaExpanded}
+      disabled={disabled}
     >
       {children}
     </button>
@@ -79,6 +81,8 @@ vi.mock('../../../components/atoms/text-input', () => {
         maxHeight,
         className,
         'aria-label': ariaLabel,
+        'aria-busy': ariaBusy,
+        disabled,
       },
       ref
     ) => (
@@ -91,6 +95,8 @@ vi.mock('../../../components/atoms/text-input', () => {
         placeholder={placeholder}
         className={className}
         aria-label={ariaLabel}
+        aria-busy={ariaBusy}
+        disabled={disabled}
         data-variant={variant}
         data-multiline={multiline}
         data-max-height={maxHeight}
@@ -199,6 +205,69 @@ describe('MessageInput', () => {
 
     await waitFor(() => {
       expect(mockOnSent).toHaveBeenCalled();
+    });
+  });
+
+  it('locks the input and does not send duplicates while a send is in flight', async () => {
+    // Keep the send promise pending so rapid Enter presses overlap in flight.
+    let resolveSend: (value: unknown) => void = () => {};
+    mockSendMessage.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSend = resolve;
+        })
+    );
+
+    render(<MessageInput onSent={mockOnSent} />);
+
+    const input = screen.getByTestId('text-input');
+    fireEvent.change(input, { target: { value: 'Hello, world!' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Only the first press fires a request; the rest are blocked while
+    // the send is in flight. The input dims and locks to signal the
+    // pending state, and keeps its text until the server confirms.
+    expect(mockSendMessage).toHaveBeenCalledTimes(1);
+    expect(input).toHaveValue('Hello, world!');
+    expect(input).toBeDisabled();
+    expect(input).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByLabelText('Open emoji picker')).toBeDisabled();
+
+    resolveSend({});
+    await waitFor(() => {
+      expect(mockOnSent).toHaveBeenCalledTimes(1);
+      expect(input).toHaveValue('');
+      expect(input).not.toBeDisabled();
+    });
+  });
+
+  it('unlocks the input with the text preserved when a send fails', async () => {
+    const sendError = new Error('network down');
+    mockSendMessage.mockRejectedValueOnce(sendError);
+    const onSendError = vi.fn();
+
+    render(<MessageInput onSent={mockOnSent} onSendError={onSendError} />);
+
+    const input = screen.getByTestId('text-input');
+    fireEvent.change(input, { target: { value: 'Hello, world!' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(onSendError).toHaveBeenCalledWith(sendError, 'Hello, world!');
+    });
+    // Text preserved, input unlocked so the user can retry.
+    expect(input).toHaveValue('Hello, world!');
+    expect(input).not.toBeDisabled();
+    expect(mockOnSent).not.toHaveBeenCalled();
+
+    // A retry after the failure resolves should now clear the input.
+    mockSendMessage.mockResolvedValueOnce({});
+    fireEvent.keyDown(input, { key: 'Enter' });
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledTimes(2);
+      expect(input).toHaveValue('');
     });
   });
 


### PR DESCRIPTION
The input was only cleared inside the sendMessage .then() callback, so rapid Enter presses would read the same text from messageRef before the first network round-trip resolved, firing sendMessage once per keypress.

Add a guard that checks if a request is inflight, only allowing a new send iff the previous has resolved or rejected. 