### PR TITLE
feat: Add ComponentsProvider for pluggable UI slot overrides

### DIFF
--- a/examples/group-chat/src/main.tsx
+++ b/examples/group-chat/src/main.tsx
@@ -25,14 +25,14 @@ export const ablyClient = new Ably.Realtime({
 export const chatClient = new ChatClient(ablyClient);
 ReactDOM.createRoot(document.querySelector('#root') || document.createElement('div')).render(
   <React.StrictMode>
-    <ThemeProvider options={{ persist: true, defaultTheme: 'light' }}>
-      <AvatarProvider>
-        <ChatSettingsProvider>
-          <ChatClientProvider client={chatClient}>
+      <ThemeProvider options={{ persist: true, defaultTheme: 'light' }}>
+        <AvatarProvider>
+          <ChatSettingsProvider>
+            <ChatClientProvider client={chatClient}>
               <App initialRoomNames={['my-first-room']} />
-          </ChatClientProvider>
-        </ChatSettingsProvider>
-      </AvatarProvider>
-    </ThemeProvider>
+            </ChatClientProvider>
+          </ChatSettingsProvider>
+        </AvatarProvider>
+      </ThemeProvider>
   </React.StrictMode>
 );

--- a/src/components/molecules/avatar-editor.tsx
+++ b/src/components/molecules/avatar-editor.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
-import { Avatar, AvatarData } from '../atoms/avatar.tsx';
+import { useComponents } from '../../hooks/use-components.tsx';
+import { Avatar as DefaultAvatar, AvatarData } from '../atoms/avatar.tsx';
 import { Button } from '../atoms/button.tsx';
 import { Icon } from '../atoms/icon.tsx';
 
@@ -86,6 +87,8 @@ export const AvatarEditor = ({
   const [avatarUrl, setAvatarUrl] = useState(currentAvatar || '');
   const [selectedColor, setSelectedColor] = useState(currentColor || '');
   const [customInitials, setCustomInitials] = useState('');
+
+  const { Avatar = DefaultAvatar } = useComponents();
   const [activeTab, setActiveTab] = useState<'presets' | 'color'>('presets');
   const [error, setError] = useState('');
 
@@ -183,13 +186,15 @@ export const AvatarEditor = ({
 
         {/* Avatar Preview */}
         <div className="flex justify-center mb-6">
-          <Avatar
-            alt={displayName}
-            src={avatarUrl}
-            color={selectedColor || currentColor || 'bg-gray-500'}
-            size="xl"
-            initials={getInitials()}
-          />
+          {Avatar !== null && (
+            <Avatar
+              alt={displayName}
+              src={avatarUrl}
+              color={selectedColor || currentColor || 'bg-gray-500'}
+              size="xl"
+              initials={getInitials()}
+            />
+          )}
         </div>
 
         {/* Tabs */}
@@ -248,7 +253,7 @@ export const AvatarEditor = ({
                   }}
                 >
                   <div className="flex flex-col items-center">
-                    <Avatar alt={preset.label} src={preset.src} size="md" />
+                    {Avatar !== null && <Avatar alt={preset.label} src={preset.src} size="md" />}
                     <span className="mt-1 text-xs text-gray-600 dark:text-gray-400">
                       {preset.label}
                     </span>

--- a/src/components/molecules/chat-message-list.tsx
+++ b/src/components/molecules/chat-message-list.tsx
@@ -9,7 +9,9 @@ import React, {
   useState,
 } from 'react';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { ChatMessage } from './chat-message.tsx';
+import { NoMoreMessagesFooter as DefaultNoMoreMessagesFooter } from './no-more-messages-footer.tsx';
 import { TypingIndicators } from './typing-indicators.tsx';
 
 export interface ChatMessageListProps
@@ -179,6 +181,8 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
     const [isAtBottom, setIsAtBottom] = useState(true);
     const [centerSerial, setCenterSerial] = useState<string | undefined>();
 
+    const { NoMoreMessagesFooter = DefaultNoMoreMessagesFooter } = useComponents();
+
     const isUserAtBottom = useCallback(() => {
       if (!containerRef.current) return false;
       const { scrollTop, scrollHeight, clientHeight } = containerRef.current;
@@ -328,10 +332,8 @@ export const ChatMessageList = forwardRef<HTMLDivElement, ChatMessageListProps>(
           </div>
         )}
 
-        {!hasMoreHistory && messages.length > 0 && (
-          <div className="flex justify-center py-4" role="status">
-            <span className="text-sm text-gray-500 dark:text-gray-400">No more messages</span>
-          </div>
+        {!hasMoreHistory && messages.length > 0 && NoMoreMessagesFooter !== null && (
+          <NoMoreMessagesFooter />
         )}
 
         {/* Messages */}

--- a/src/components/molecules/chat-message.tsx
+++ b/src/components/molecules/chat-message.tsx
@@ -4,15 +4,16 @@ import { clsx } from 'clsx';
 import React, { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { useUserAvatar } from '../../hooks/use-user-avatar.tsx';
-import { Avatar } from '../atoms/avatar.tsx';
+import { Avatar as DefaultAvatar } from '../atoms/avatar.tsx';
 import { Button } from '../atoms/button.tsx';
 import { Icon } from '../atoms/icon.tsx';
 import { TextInput } from '../atoms/text-input.tsx';
 import { Tooltip } from '../atoms/tooltip.tsx';
 import { ConfirmDialog } from './confirm-dialog.tsx';
-import { EmojiPicker } from './emoji-picker.tsx';
-import { MessageActions } from './message-actions.tsx';
+import { EmojiPicker as DefaultEmojiPicker } from './emoji-picker.tsx';
+import { MessageActions as DefaultMessageActions } from './message-actions.tsx';
 import { MessageReactions } from './message-reactions.tsx';
 
 /**
@@ -136,6 +137,12 @@ export const ChatMessage = ({
   const isOwn = message.clientId === clientId;
 
   const { userAvatar } = useUserAvatar({ clientId: message.clientId });
+
+  const {
+    Avatar = DefaultAvatar,
+    EmojiPicker = DefaultEmojiPicker,
+    MessageActions = DefaultMessageActions,
+  } = useComponents();
 
   /**
    * Enables edit mode for the message
@@ -382,13 +389,15 @@ export const ChatMessage = ({
           aria-label={`Avatar for ${message.clientId}`}
           tabIndex={isOwn ? 0 : undefined}
         >
-          <Avatar
-            alt={userAvatar?.displayName}
-            src={userAvatar?.src}
-            color={userAvatar?.color}
-            size="sm"
-            initials={userAvatar?.initials}
-          />
+          {Avatar !== null && (
+            <Avatar
+              alt={userAvatar?.displayName}
+              src={userAvatar?.src}
+              color={userAvatar?.color}
+              size="sm"
+              initials={userAvatar?.initials}
+            />
+          )}
         </div>
 
         {/* Avatar Hover Tooltip */}
@@ -481,14 +490,17 @@ export const ChatMessage = ({
           </div>
 
           {/* Message Actions to update/delete/react */}
-          {isHovered && !isEditing && message.action !== ChatMessageAction.MessageDelete && (
-            <MessageActions
-              isOwn={isOwn}
-              onReactionButtonClicked={handleAddReaction}
-              onEditButtonClicked={handleEdit}
-              onDeleteButtonClicked={handleDelete}
-            />
-          )}
+          {isHovered &&
+            !isEditing &&
+            message.action !== ChatMessageAction.MessageDelete &&
+            MessageActions !== null && (
+              <MessageActions
+                isOwn={isOwn}
+                onReactionButtonClicked={handleAddReaction}
+                onEditButtonClicked={handleEdit}
+                onDeleteButtonClicked={handleDelete}
+              />
+            )}
         </div>
 
         {/* Reactions will be rendered below the relevant message */}
@@ -515,7 +527,7 @@ export const ChatMessage = ({
       </div>
 
       {/* Emoji Picker */}
-      {showEmojiPicker && (
+      {showEmojiPicker && EmojiPicker !== null && (
         <EmojiPicker
           onClose={() => {
             setShowEmojiPicker(false);

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -13,6 +13,10 @@ export { EmojiWheel, type EmojiWheelProps } from './emoji-wheel.tsx';
 export { MessageActions, type MessageActionsProps } from './message-actions.tsx';
 export { MessageInput, type MessageInputProps } from './message-input.tsx';
 export { MessageReactions, type MessageReactionsProps } from './message-reactions.tsx';
+export {
+  NoMoreMessagesFooter,
+  type NoMoreMessagesFooterProps,
+} from './no-more-messages-footer.tsx';
 export { Participant, type ParticipantProps } from './participant.tsx';
 export { ParticipantList, type ParticipantListProps } from './participant-list.tsx';
 export { PresenceCount, type PresenceCountProps } from './presence-count.tsx';

--- a/src/components/molecules/message-input.tsx
+++ b/src/components/molecules/message-input.tsx
@@ -2,10 +2,11 @@ import { ErrorInfo, Message } from '@ably/chat';
 import { useMessages, useTyping } from '@ably/chat/react';
 import React, { ChangeEvent, KeyboardEvent, useCallback, useRef, useState } from 'react';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { Button } from '../atoms/button.tsx';
 import { Icon } from '../atoms/icon.tsx';
 import { TextInput } from '../atoms/text-input.tsx';
-import { EmojiPicker } from './emoji-picker.tsx';
+import { EmojiPicker as DefaultEmojiPicker } from './emoji-picker.tsx';
 
 /**
  * Props for the MessageInput component
@@ -145,6 +146,8 @@ export const MessageInput = ({
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const { keystroke, stop } = useTyping();
   const { sendMessage } = useMessages();
+  const { EmojiPicker = DefaultEmojiPicker } = useComponents();
+  const emojiPickerDisabled = EmojiPicker === null;
 
   /**
    * Handles sending the message, clearing the input, and stopping typing indicators
@@ -295,23 +298,25 @@ export const MessageInput = ({
           />
 
           {/* Emoji Button */}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 self-end mb-1"
-            onClick={handleEmojiButtonClick}
-            data-emoji-button
-            aria-label="Open emoji picker"
-            aria-haspopup="dialog"
-            aria-expanded={showEmojiPicker}
-          >
-            <Icon name="emoji" size="md" aria-hidden={true} />
-          </Button>
+          {!emojiPickerDisabled && (
+            <Button
+              variant="ghost"
+              size="sm"
+              className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 self-end mb-1"
+              onClick={handleEmojiButtonClick}
+              data-emoji-button
+              aria-label="Open emoji picker"
+              aria-haspopup="dialog"
+              aria-expanded={showEmojiPicker}
+            >
+              <Icon name="emoji" size="md" aria-hidden={true} />
+            </Button>
+          )}
         </div>
       </div>
 
       {/* Emoji Picker */}
-      {showEmojiPicker && (
+      {showEmojiPicker && !emojiPickerDisabled && (
         <EmojiPicker
           onClose={() => {
             setShowEmojiPicker(false);

--- a/src/components/molecules/no-more-messages-footer.tsx
+++ b/src/components/molecules/no-more-messages-footer.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+/**
+ * Props for {@link NoMoreMessagesFooter}.
+ */
+export interface NoMoreMessagesFooterProps {
+  /**
+   * Optional label displayed in the footer.
+   *
+   * @default "No more messages"
+   */
+  label?: string;
+}
+
+/**
+ * Footer rendered at the top of a `ChatMessageList` once the full history
+ * has been loaded.
+ *
+ * This component exists as a distinct building block so it can be replaced
+ * or suppressed via {@link ComponentsProvider} overrides
+ * (for example `overrides={{ NoMoreMessagesFooter: null }}`).
+ */
+export const NoMoreMessagesFooter = ({ label = 'No more messages' }: NoMoreMessagesFooterProps) => (
+  <div className="flex justify-center py-4" role="status">
+    <span className="text-sm text-gray-500 dark:text-gray-400">{label}</span>
+  </div>
+);

--- a/src/components/molecules/participant.tsx
+++ b/src/components/molecules/participant.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { useUserAvatar } from '../../hooks/use-user-avatar.tsx';
-import { Avatar, AvatarData } from '../atoms/avatar.tsx';
+import { Avatar as DefaultAvatar, AvatarData } from '../atoms/avatar.tsx';
 import { TypingDots } from '../atoms/typing-dots.tsx';
 
 /**
@@ -93,6 +94,8 @@ export const Participant = ({
   const { userAvatar } = useUserAvatar({ clientId });
   const avatarData = propAvatar || userAvatar;
 
+  const { Avatar = DefaultAvatar } = useComponents();
+
   // Use the helper function
   const statusText = getParticipantStatus(isTyping, isPresent, isSelf);
 
@@ -103,13 +106,15 @@ export const Participant = ({
       aria-label={`${isSelf ? 'You' : clientId}, ${statusText}`}
     >
       <div className="relative">
-        <Avatar
-          alt={avatarData?.displayName}
-          src={avatarData?.src}
-          color={avatarData?.color}
-          size="sm"
-          initials={avatarData?.initials}
-        />
+        {Avatar !== null && (
+          <Avatar
+            alt={avatarData?.displayName}
+            src={avatarData?.src}
+            color={avatarData?.color}
+            size="sm"
+            initials={avatarData?.initials}
+          />
+        )}
         {/* Presence Icon */}
         <div
           className={`absolute -bottom-0.5 -right-0.5 w-3 h-3 rounded-full border-2 border-white dark:border-gray-800 ${

--- a/src/components/molecules/room-info.tsx
+++ b/src/components/molecules/room-info.tsx
@@ -2,8 +2,9 @@ import { useChatClient, usePresenceListener, useRoom, useTyping } from '@ably/ch
 import { clsx } from 'clsx';
 import React, { useState } from 'react';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { useRoomAvatar } from '../../hooks/use-room-avatar.tsx';
-import { Avatar, AvatarData } from '../atoms/avatar.tsx';
+import { Avatar as DefaultAvatar, AvatarData } from '../atoms/avatar.tsx';
 import { ParticipantList } from './participant-list.tsx';
 import { PresenceCount } from './presence-count.tsx';
 import { PresenceIndicators } from './presence-indicators.tsx';
@@ -158,6 +159,8 @@ export const RoomInfo = ({
   const { roomAvatar } = useRoomAvatar({ roomName });
   const roomAvatarData = propRoomAvatar || roomAvatar;
 
+  const { Avatar = DefaultAvatar } = useComponents();
+
   const onToggle = () => {
     setShowTooltip(false); // Hide tooltip when toggling participant list
     setIsOpen(!isOpen);
@@ -223,13 +226,15 @@ export const RoomInfo = ({
           }}
         >
           <div className="relative">
-            <Avatar
-              alt={roomAvatarData?.displayName}
-              src={roomAvatarData?.src}
-              color={roomAvatarData?.color}
-              size="lg"
-              initials={roomAvatarData?.initials}
-            />
+            {Avatar !== null && (
+              <Avatar
+                alt={roomAvatarData?.displayName}
+                src={roomAvatarData?.src}
+                color={roomAvatarData?.color}
+                size="lg"
+                initials={roomAvatarData?.initials}
+              />
+            )}
           </div>
 
           {/* Present Count Badge */}

--- a/src/components/molecules/room-list-item.tsx
+++ b/src/components/molecules/room-list-item.tsx
@@ -1,8 +1,9 @@
 import { useOccupancy } from '@ably/chat/react';
 import React from 'react';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { useRoomAvatar } from '../../hooks/use-room-avatar.tsx';
-import { Avatar, AvatarData } from '../atoms/avatar.tsx';
+import { Avatar as DefaultAvatar, AvatarData } from '../atoms/avatar.tsx';
 import { Button } from '../atoms/button.tsx';
 import { Icon } from '../atoms/icon.tsx';
 import { TypingIndicators } from './typing-indicators.tsx';
@@ -116,6 +117,8 @@ export const RoomListItem = React.memo(function RoomListItem({
 
   const { roomAvatar } = useRoomAvatar({ roomName });
   const roomAvatarData = propAvatar || roomAvatar;
+
+  const { Avatar = DefaultAvatar } = useComponents();
   /**
    * Checks if the room has any active users
    *
@@ -149,13 +152,15 @@ export const RoomListItem = React.memo(function RoomListItem({
             }
           }}
         >
-          <Avatar
-            alt={roomAvatarData?.displayName}
-            src={roomAvatarData?.src}
-            color={roomAvatarData?.color}
-            size="md"
-            initials={roomAvatarData?.initials}
-          />
+          {Avatar !== null && (
+            <Avatar
+              alt={roomAvatarData?.displayName}
+              src={roomAvatarData?.src}
+              color={roomAvatarData?.color}
+              size="md"
+              initials={roomAvatarData?.initials}
+            />
+          )}
           {isSelected && (
             <div className="absolute -bottom-0.5 -right-0.5 w-3 h-3 bg-green-500 rounded-full border-2 border-white dark:border-gray-900" />
           )}
@@ -183,13 +188,15 @@ export const RoomListItem = React.memo(function RoomListItem({
       }}
     >
       <div className="relative">
-        <Avatar
-          alt={roomAvatarData?.displayName}
-          src={roomAvatarData?.src}
-          color={roomAvatarData?.color}
-          size="md"
-          initials={roomAvatarData?.initials}
-        />
+        {Avatar !== null && (
+          <Avatar
+            alt={roomAvatarData?.displayName}
+            src={roomAvatarData?.src}
+            color={roomAvatarData?.color}
+            size="md"
+            initials={roomAvatarData?.initials}
+          />
+        )}
 
         {/* Present indicator */}
         {isActive && (

--- a/src/components/molecules/room-reaction.tsx
+++ b/src/components/molecules/room-reaction.tsx
@@ -3,9 +3,10 @@ import { useRoomReactions } from '@ably/chat/react';
 import { clsx } from 'clsx';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useComponents } from '../../hooks/use-components.tsx';
 import { useThrottle } from '../../hooks/use-throttle.tsx';
 import { EmojiBurst } from './emoji-burst.tsx';
-import { EmojiWheel } from './emoji-wheel.tsx';
+import { EmojiWheel as DefaultEmojiWheel } from './emoji-wheel.tsx';
 
 /**
  * Props for the RoomReaction component
@@ -152,6 +153,8 @@ export const RoomReaction = ({
   const reactionButtonRef = useRef<HTMLButtonElement>(null);
   const longPressTimerRef = useRef<NodeJS.Timeout | undefined>(undefined);
   const isLongPressRef = useRef(false);
+
+  const { EmojiWheel = DefaultEmojiWheel } = useComponents();
 
   /**
    * Handles incoming room reactions from other users.
@@ -399,12 +402,14 @@ export const RoomReaction = ({
       </button>
 
       {/* Emoji Selection Wheel */}
-      <EmojiWheel
-        isOpen={showEmojiWheel}
-        position={emojiWheelPosition}
-        onEmojiSelect={handleEmojiSelect}
-        onClose={handleEmojiWheelClose}
-      />
+      {EmojiWheel !== null && (
+        <EmojiWheel
+          isOpen={showEmojiWheel}
+          position={emojiWheelPosition}
+          onEmojiSelect={handleEmojiSelect}
+          onClose={handleEmojiWheelClose}
+        />
+      )}
 
       {/* Emoji Burst Animation */}
       <EmojiBurst

--- a/src/context/components-context.tsx
+++ b/src/context/components-context.tsx
@@ -1,0 +1,51 @@
+import { ComponentType, createContext } from 'react';
+
+import type { AvatarProps } from '../components/atoms/avatar.tsx';
+import type { EmojiPickerProps } from '../components/molecules/emoji-picker.tsx';
+import type { EmojiWheelProps } from '../components/molecules/emoji-wheel.tsx';
+import type { MessageActionsProps } from '../components/molecules/message-actions.tsx';
+import type { NoMoreMessagesFooterProps } from '../components/molecules/no-more-messages-footer.tsx';
+
+/**
+ * A component override.
+ *
+ * - A `ComponentType<P>` replaces the default component.
+ * - `null` suppresses rendering at every call site that consumes this slot.
+ */
+export type ComponentOverride<P> = ComponentType<P> | null;
+
+/**
+ * The set of UI components that can be overridden through the
+ * {@link ComponentsProvider}.
+ *
+ * Each entry is optional; anything not supplied falls through to the
+ * default component shipped with the UI kit. Supplying `null` hides the
+ * slot entirely, which is useful for disabling built-in UI (for example,
+ * passing `EmojiPicker: null` to a `MessageInput` that should not expose
+ * emojis).
+ */
+export interface ComponentOverrides {
+  /** Renders user and room avatars. */
+  Avatar?: ComponentOverride<AvatarProps>;
+  /** Renders the emoji picker inside `MessageInput` and `ChatMessage`. */
+  EmojiPicker?: ComponentOverride<EmojiPickerProps>;
+  /** Renders the radial emoji-selection wheel used by `RoomReaction`. */
+  EmojiWheel?: ComponentOverride<EmojiWheelProps>;
+  /** Renders the hover toolbar of message actions (edit, delete, react). */
+  MessageActions?: ComponentOverride<MessageActionsProps>;
+  /**
+   * Renders the footer shown in `ChatMessageList` once history has been
+   * fully loaded.
+   */
+  NoMoreMessagesFooter?: ComponentOverride<NoMoreMessagesFooterProps>;
+}
+
+/**
+ * Context value holding component overrides.
+ *
+ * The default is an empty object, so the provider is opt-in: unwrapped
+ * consumers transparently get the shipped defaults.
+ *
+ * @internal
+ */
+export const ComponentsContext = createContext<ComponentOverrides>({});

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,3 +1,7 @@
 export { type AvatarContextType } from './avatar-context.tsx';
 export { type ChatSettings, type ChatSettingsContextType } from './chat-settings-context.tsx';
+export {
+  type ComponentOverride,
+  type ComponentOverrides,
+} from './components-context.tsx';
 export { type ThemeContextType } from './theme-context.tsx';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export { useAvatar } from './use-avatar.tsx';
 export { useChatSettings } from './use-chat-settings.tsx';
+export { useComponents } from './use-components.tsx';
 export {
   useRoomAvatar,
   type UseRoomAvatarProps,

--- a/src/hooks/use-components.tsx
+++ b/src/hooks/use-components.tsx
@@ -1,0 +1,24 @@
+import { useContext } from 'react';
+
+import { ComponentOverrides, ComponentsContext } from '../context/components-context.tsx';
+
+/**
+ * Hook to read the current set of component overrides.
+ *
+ * Unlike {@link useChatSettings}, this hook never throws — if no
+ * {@link ComponentsProvider} wraps the tree, the hook returns an empty
+ * override set, so components silently fall back to their built-in defaults.
+ *
+ * Typical consumption at a render site:
+ *
+ * ```tsx
+ * const { EmojiPicker = DefaultEmojiPicker } = useComponents();
+ * // `EmojiPicker` is now either the shipped default, a custom
+ * // component, or `null` (in which case callers should not render it).
+ * ```
+ *
+ * @returns The current overrides (empty when no provider is present).
+ *
+ * @public
+ */
+export const useComponents = (): ComponentOverrides => useContext(ComponentsContext);

--- a/src/providers/components-provider.tsx
+++ b/src/providers/components-provider.tsx
@@ -1,0 +1,72 @@
+import React, { ReactNode, useMemo } from 'react';
+
+import { ComponentOverrides, ComponentsContext } from '../context/components-context.tsx';
+import { useComponents } from '../hooks/use-components.tsx';
+
+/**
+ * Props for {@link ComponentsProvider}.
+ */
+export interface ComponentsProviderProps {
+  /** Children rendered inside the provider scope. */
+  children?: ReactNode;
+  /**
+   * The overrides to apply to this subtree. Each entry either replaces the
+   * default shipped component (`ComponentType`) or suppresses it (`null`).
+   *
+   * Nested providers merge with their parent: children inherit every
+   * override from the enclosing scope, and may individually replace or
+   * hide any of them.
+   *
+   * The prop value should be stable between renders — wrap it in
+   * `useMemo` on the consumer side, otherwise every render will
+   * invalidate the merged value and re-render every downstream consumer.
+   */
+  overrides?: ComponentOverrides;
+}
+
+/**
+ * Provides component overrides to descendant UI-kit components.
+ *
+ * The provider inherits overrides from any enclosing `ComponentsProvider`,
+ * shallow-merges the new ones on top, and memoizes the merged object so
+ * downstream consumers only re-render when an override changes.
+ *
+ * @example
+ * Hide the emoji picker and swap the avatar application-wide:
+ *
+ * ```tsx
+ * const overrides = useMemo(
+ *   () => ({
+ *     EmojiPicker: null,
+ *     Avatar: BrandAvatar,
+ *   }),
+ *   []
+ * );
+ *
+ * <ComponentsProvider overrides={overrides}>
+ *   <ChatWindow ... />
+ * </ComponentsProvider>
+ * ```
+ *
+ * @example
+ * Scope an override to a subtree:
+ *
+ * ```tsx
+ * <ComponentsProvider overrides={{ Avatar: BrandAvatar }}>
+ *   <ChatWindow ... />
+ *   <ComponentsProvider overrides={{ MessageActions: null }}>
+ *     <ReadOnlyRoom ... />
+ *   </ComponentsProvider>
+ * </ComponentsProvider>
+ * ```
+ *
+ * @public
+ */
+export const ComponentsProvider = ({ children, overrides }: ComponentsProviderProps) => {
+  const parent = useComponents();
+  const merged = useMemo<ComponentOverrides>(
+    () => ({ ...parent, ...overrides }),
+    [parent, overrides]
+  );
+  return <ComponentsContext.Provider value={merged}>{children}</ComponentsContext.Provider>;
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -6,6 +6,7 @@ export {
   type PersistedAvatarData,
 } from './avatar-provider.tsx';
 export { ChatSettingsProvider, type ChatSettingsProviderProps } from './chat-settings-provider.tsx';
+export { ComponentsProvider, type ComponentsProviderProps } from './components-provider.tsx';
 export {
   type ThemeChangeCallback,
   type ThemeOptions,

--- a/src/test/providers/components-provider.test.tsx
+++ b/src/test/providers/components-provider.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom';
+
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { useComponents } from '../../hooks/use-components.tsx';
+import { ComponentsProvider } from '../../providers/components-provider.tsx';
+
+// A marker component stands in for any overridable slot — the tests only
+// need to tell which component was selected, not exercise real rendering.
+const makeMarker =
+  (id: string) =>
+  // eslint-disable-next-line react/display-name
+  () => <span data-testid={id} />;
+
+const DefaultAvatar = makeMarker('default-avatar');
+const CustomAvatar = makeMarker('custom-avatar');
+const ParentEmojiPicker = makeMarker('parent-emoji-picker');
+const ChildEmojiPicker = makeMarker('child-emoji-picker');
+
+/**
+ * Probes read the context and render whichever slot the tests care about,
+ * falling back to a default when no override is in scope and rendering
+ * nothing when the override is `null`.
+ */
+const AvatarProbe = () => {
+  const { Avatar = DefaultAvatar } = useComponents();
+  if (Avatar === null) return <span data-testid="avatar-hidden" />;
+  return <Avatar />;
+};
+
+const EmojiPickerProbe = () => {
+  const { EmojiPicker } = useComponents();
+  if (!EmojiPicker) return <span data-testid="emoji-picker-absent" />;
+  return <EmojiPicker />;
+};
+
+describe('ComponentsProvider', () => {
+  afterEach(cleanup);
+
+  it('returns an empty override set when no provider wraps the tree', () => {
+    render(<AvatarProbe />);
+    expect(screen.getByTestId('default-avatar')).toBeInTheDocument();
+  });
+
+  it('supplies overrides to descendants', () => {
+    render(
+      <ComponentsProvider overrides={{ Avatar: CustomAvatar }}>
+        <AvatarProbe />
+      </ComponentsProvider>
+    );
+
+    expect(screen.queryByTestId('default-avatar')).not.toBeInTheDocument();
+    expect(screen.getByTestId('custom-avatar')).toBeInTheDocument();
+  });
+
+  it('treats a null override as "do not render"', () => {
+    render(
+      <ComponentsProvider overrides={{ Avatar: null }}>
+        <AvatarProbe />
+      </ComponentsProvider>
+    );
+
+    expect(screen.getByTestId('avatar-hidden')).toBeInTheDocument();
+    expect(screen.queryByTestId('default-avatar')).not.toBeInTheDocument();
+  });
+
+  it('merges overrides from nested providers, with child entries taking precedence', () => {
+    render(
+      <ComponentsProvider
+        overrides={{ Avatar: CustomAvatar, EmojiPicker: ParentEmojiPicker }}
+      >
+        <ComponentsProvider overrides={{ EmojiPicker: ChildEmojiPicker }}>
+          <AvatarProbe />
+          <EmojiPickerProbe />
+        </ComponentsProvider>
+      </ComponentsProvider>
+    );
+
+    // Avatar inherited from the parent provider.
+    expect(screen.getByTestId('custom-avatar')).toBeInTheDocument();
+    // EmojiPicker was replaced at the child level.
+    expect(screen.getByTestId('child-emoji-picker')).toBeInTheDocument();
+    expect(screen.queryByTestId('parent-emoji-picker')).not.toBeInTheDocument();
+  });
+
+  it('lets a nested provider hide an inherited slot by setting it to null', () => {
+    render(
+      <ComponentsProvider overrides={{ Avatar: CustomAvatar }}>
+        <ComponentsProvider overrides={{ Avatar: null }}>
+          <AvatarProbe />
+        </ComponentsProvider>
+      </ComponentsProvider>
+    );
+
+    expect(screen.getByTestId('avatar-hidden')).toBeInTheDocument();
+    expect(screen.queryByTestId('custom-avatar')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Introduce a context-based component override mechanism so consumers can swap or suppress built-in UI pieces without forking the kit. Addresses the root cause behind the concrete pain points in #41: removing the emoji picker from MessageInput, hiding the "No more messages" footer, and disabling message actions per subtree.

Each slot accepts either a ComponentType (swap) or null (suppress). Nested providers merge with their enclosing scope; child overrides take precedence and may hide inherited slots.